### PR TITLE
feat(PLAT-2052): :sparkles: expose user profile data

### DIFF
--- a/.changeset/stupid-lemons-glow.md
+++ b/.changeset/stupid-lemons-glow.md
@@ -1,0 +1,5 @@
+---
+"@fleek-platform/login-button": minor
+---
+
+expose user profile data

--- a/package.json
+++ b/package.json
@@ -1,20 +1,13 @@
 {
   "name": "@fleek-platform/login-button",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "A standalone login component with an embedded Dynamic modal that functions independently of host application.",
   "repository": "https://github.com/fleek-platform/login-button",
   "homepage": "https://github.com/fleek-platform/login-button",
-  "keywords": [
-    "fleek",
-    "auth",
-    "dynamic"
-  ],
+  "keywords": ["fleek", "auth", "dynamic"],
   "license": "MIT",
   "type": "module",
-  "files": [
-    "dist",
-    "src"
-  ],
+  "files": ["dist", "src"],
   "exports": {
     ".": {
       "import": "./dist/bundle.js",

--- a/src/providers/DynamicProvider.tsx
+++ b/src/providers/DynamicProvider.tsx
@@ -24,6 +24,7 @@ export const DynamicProvider: FC<DynamicProviderProps> = ({ children, graphqlApi
     setAccessToken,
     setAuthToken,
     reset: resetStore,
+    setUserProfile,
     setIsNewUser,
     triggerLoginModal,
     setTriggerLoginModal,
@@ -61,6 +62,7 @@ export const DynamicProvider: FC<DynamicProviderProps> = ({ children, graphqlApi
         setIsLoading(true);
         setAuthToken(authToken);
         setError(undefined);
+        setUserProfile(user);
         setIsNewUser(!!user?.newUser);
 
         const result = await generateUserSessionDetails(graphqlApiUrl, authToken);
@@ -103,7 +105,7 @@ export const DynamicProvider: FC<DynamicProviderProps> = ({ children, graphqlApi
   useEffect(() => {
     const authToken = cookies.get('authToken');
     const accessToken = cookies.get('accessToken');
-    
+
     if (!authToken) {
       return;
     }

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -4,6 +4,7 @@ import { loginWithDynamic } from '../api/graphql-client';
 import { useConfigStore } from './configStore';
 import { getStoreName } from '../utils/store';
 import { decodeAccessToken } from '../utils/token';
+import type { UserProfile } from '@dynamic-labs/sdk-react-core';
 
 type TriggerLoginModal = (open: boolean) => void;
 type TriggerLogout = () => void;
@@ -17,6 +18,7 @@ export interface AuthStore {
   projectId: string;
   isLoggedIn: boolean;
   isLoggingIn: boolean;
+  userProfile?: UserProfile;
   triggerLoginModal?: TriggerLoginModal;
   triggerLogout?: TriggerLogout;
   setAccessToken: (value: string) => void;
@@ -28,13 +30,22 @@ export interface AuthStore {
   updateAccessTokenByProjectId: (projectId: string) => Promise<void>;
   reset: () => void;
   setIsNewUser: (isNewUser: boolean) => void;
+  setUserProfile: (userProfile: UserProfile) => void;
   setProjectId: (projectId: string) => void;
 }
 
 export interface AuthState
   extends Pick<
     AuthStore,
-    'accessToken' | 'authToken' | 'projectId' | 'isNewUser' | 'triggerLoginModal' | 'triggerLogout' | 'isLoggedIn' | 'isLoggingIn'
+    | 'accessToken'
+    | 'authToken'
+    | 'projectId'
+    | 'isNewUser'
+    | 'triggerLoginModal'
+    | 'triggerLogout'
+    | 'isLoggedIn'
+    | 'isLoggingIn'
+    | 'userProfile'
   > {}
 
 export const initialState: AuthState = {
@@ -44,6 +55,7 @@ export const initialState: AuthState = {
   isNewUser: false,
   isLoggedIn: false,
   isLoggingIn: false,
+  userProfile: undefined,
 };
 
 export const useAuthStore = create<AuthStore>()(
@@ -106,6 +118,7 @@ export const useAuthStore = create<AuthStore>()(
           throw err;
         }
       },
+      setUserProfile: (userProfile: UserProfile) => set({ userProfile }),
       setIsNewUser: (isNewUser: boolean) => set({ isNewUser }),
       setTriggerLoginModal: (triggerLoginModal: TriggerLoginModal) => set({ triggerLoginModal }),
       setTriggerLogout: (triggerLogout: TriggerLogout) => set({ triggerLogout }),
@@ -115,7 +128,8 @@ export const useAuthStore = create<AuthStore>()(
       name,
       storage: createJSONStorage(() => localStorage),
       // Persist only selected keys
-      partialize: ({ accessToken, authToken, projectId, isLoggedIn, isNewUser }) => ({
+      partialize: ({ accessToken, authToken, projectId, isLoggedIn, isNewUser, userProfile }) => ({
+        userProfile,
         accessToken,
         authToken,
         projectId,


### PR DESCRIPTION
## Why?
I need to expose the user profile to have access to the user email. Took the liberty of exposing the whole profile instead of just the email as it may be useful in other cases.
That email is to be used under the scope of PLAT-2052

## How?

- Added userProfile to the list of exposed data

## Tickets?

- [PLAT-2052](https://linear.app/fleekxyz/issue/PLAT-2052/tweak-the-twitter-pixel-code-as-per-azuls-specifications)

## Contribution checklist?

- [ ] The commit messages are detailed
- [ ] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [ ] Document filename is named after the slug
- [ ] You've reviewed spelling using a grammar checker
- [ ] For documentation, guides or references, you've tested the commands and steps
- [ ] You've done enough research before writing

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] The Components are escaping output (to prevent XSS)

## References?

Optionally, provide references such as links

## Preview?

Optionally, provide the preview url here
