### PR TITLE
refactor: 💡 Use null for empty dynamic utils component

### DIFF
--- a/.changeset/spicy-coats-begin.md
+++ b/.changeset/spicy-coats-begin.md
@@ -1,0 +1,5 @@
+---
+"@fleek-platform/login-button": patch
+---
+
+Make DynamicUtils return nullish

--- a/src/providers/DynamicProvider.tsx
+++ b/src/providers/DynamicProvider.tsx
@@ -138,7 +138,7 @@ export const DynamicProvider: FC<DynamicProviderProps> = ({ children, graphqlApi
       setTriggerLogout(handleLogOut);
     }, [setTriggerLogout, sdkHasLoaded]);
 
-    return <></>;
+    return null;
   };
 
   const settings = {


### PR DESCRIPTION
## Why?

Use null for empty dynamic utils component, to prevent empty div

## How?

- Return null instead of <></>

## Tickets?

- [PLAT-2088](https://linear.app/fleekxyz/issue/PLAT-2088/login-button-use-null-for-empty-dynamic-utils-component)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [ ] Document filename is named after the slug
- [ ] You've reviewed spelling using a grammar checker
- [ ] For documentation, guides or references, you've tested the commands and steps
- [ ] You've done enough research before writing

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] The Components are escaping output (to prevent XSS)

## References?

Optionally, provide references such as links

## Preview?

Optionally, provide the preview url here
