### PR TITLE
docs(readme): fix graphql env variable name

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Open your favourite text editor to edit the file.
 Here's an example for staging environent variable values:
 
 ```sh
-PUBLIC_GRAPHQL_ENDPOINT="https://graphql.service.staging.fleeksandbox.xyz/graphql"
+PUBLIC_GRAPHQL_API_URL="https://graphql.service.staging.fleeksandbox.xyz/graphql"
 PUBLIC_DYNAMIC_ENVIRONMENT_ID="c4d4ccad-9460-419c-9ca3-494488f8c892"
 ```
 


### PR DESCRIPTION
## Why?

README states the wrong environment variable for the graphql api url.

## How?

- Changed `PUBLIC_GRAPHQL_ENDPOINT` to `PUBLIC_GRAPHQL_API_URL`

## Tickets?

- [PLAT-2091](https://linear.app/fleekxyz/issue/PLAT-2091/login-button-repo-fix-graphql-api-url-env-variable-in-readme)

## Contribution checklist?

- [x] The commit messages are detailed
- [ ] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [ ] Document filename is named after the slug
- [ ] You've reviewed spelling using a grammar checker
- [ ] For documentation, guides or references, you've tested the commands and steps
- [ ] You've done enough research before writing

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] The Components are escaping output (to prevent XSS)

## References?

Optionally, provide references such as links

## Preview?

Optionally, provide the preview url here
