### PR TITLE
fix(dynamic): replace scale override with em rules

### DIFF
--- a/.changeset/spicy-fishes-work.md
+++ b/.changeset/spicy-fishes-work.md
@@ -1,0 +1,5 @@
+---
+"@fleek-platform/login-button": patch
+---
+
+Replace CSS scale with em based size overrides

--- a/build.ts
+++ b/build.ts
@@ -24,6 +24,9 @@ const main = async () => {
     sourcemap: true,
     external,
     minify: true,
+    loader: {
+      '.css': 'text',
+    },
   };
 
   try {

--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -1,0 +1,1 @@
+declare module '*.css';

--- a/src/css/index.css
+++ b/src/css/index.css
@@ -1,0 +1,73 @@
+.dynamic-shadow-dom {
+  font-size: 16px;
+
+  --dynamic-search-border-radius: 1em;
+  --dynamic-border-radius: 1.5em;
+  --dynamic-text-size-body-mini: 0.6875em;
+  --dynamic-text-size-body-normal: 0.9375em;
+  --dynamic-text-size-body-small: 0.75em;
+  --dynamic-text-size-button-primary: 0.875em;
+  --dynamic-text-size-button-secondary: 0.75em;
+  --dynamic-text-size-numbers-big: 0.875em;
+  --dynamic-text-size-numbers-medium: 0.75em;
+  --dynamic-text-size-title: 1.125em;
+  --dynamic-modal-width: 22.5em;
+  --dynamic-modal-padding: 1.5em;
+  --dynamic-wallet-list-tile-padding: 0.75em;
+  --dynamic-wallet-list-tile-gap: 0.375em;
+  --dynamic-wallet-list-max-height: 16.25em;
+  --dynamic-wallet-list-tile-border-radius: 0.75em;
+  --dynamic-initial-view-content-padding: 0em 1.5em 1.5em;
+  --dynamic-button-primary-font-size: 0.875em;
+  --dynamic-button-secondary-font-size: 0.75em;
+  --dynamic-search-padding: 0 1.5em 0.5em;
+  --dynamic-layout-content-padding: 0 1.5em 1.5em;
+  --dynamic-layout-content-error-padding: 1.5em 1.5em 1.5em;
+  --dynamic-footer-padding: 0.75em 1.5em 0.75em;
+  --dynamic-header-padding: 1.5em 1.5em 1.25em;
+}
+
+.dynamic-shadow-dom .button--padding-login-screen-height {
+  height: 2.5em;
+}
+
+.dynamic-shadow-dom .social-sign-in--tile {
+  height: 2.5em;
+}
+
+.dynamic-shadow-dom .connect-with-wallet-button {
+  height: 2.5em;
+}
+
+.dynamic-shadow-dom .input__container .input {
+  font-size: 0.9375em;
+}
+
+.dynamic-shadow-dom .input__container .input__label {
+  font-size: 0.625em;
+}
+
+.dynamic-shadow-dom .input__container--dense .input:placeholder-shown ~ .input__label {
+  font-size: 0.9375em;
+  top: 0.75em;
+}
+
+.dynamic-shadow-dom .input__container--dense .input:focus ~ .input__label {
+  font-size: 0.625em;
+  top: 0.4375em;
+}
+
+.dynamic-shadow-dom .input__container--dense .input {
+  padding: 1.125em 0.5em 0.375em;
+}
+
+.dynamic-shadow-dom .powered-by-dynamic__logo {
+  margin-top: 0.0625em;
+  max-width: 3.6875em;
+  width: 3.6875em;
+}
+
+.dynamic-shadow-dom .header__icon svg {
+  height: 1.5em;
+  width: 1.5em;
+}

--- a/src/providers/DynamicProvider.tsx
+++ b/src/providers/DynamicProvider.tsx
@@ -10,6 +10,7 @@ import { cookies } from '../utils/cookies';
 import { type LoginProviderChildrenProps } from './LoginProvider';
 import { clearStorageByMatchTerm } from '../utils/browser';
 import { decodeAccessToken } from '../utils/token';
+import cssOverrides from '../css/index.css';
 
 export type DynamicProviderProps = {
   graphqlApiUrl: string;
@@ -152,7 +153,7 @@ export const DynamicProvider: FC<DynamicProviderProps> = ({ children, graphqlApi
     // using scale might not be appropriate
     // https://docs.dynamic.xyz/design-customizations/css/css-variables#css-variables
     shadowDOMEnabled: false,
-    cssOverrides: '.modal__items { scale: 1.5 }',
+    cssOverrides,
   };
 
   return (

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,6 @@
     "moduleResolution": "node",
     "resolveJsonModule": true
   },
-  "include": ["src/**/*"],
+  "include": ["src/**/*", "declarations.d.ts"],
   "exclude": ["node_modules", "dist", "src/examples/**/*"]
 }


### PR DESCRIPTION
## Why?

The login modal is broken on mobile because the `login-button` package currently applies a `scale(1.5)` CSS override. This was initially added to compensate for the modal using `rem` units while the website's `<html>` tag has a `font-size` of 62.5%, which makes the modal appear too small. However, scaling is not a reliable solution, as it causes the modal to overflow beyond the screen boundaries on mobile.  

## How?

- Introduced `css/index.css`, which contains only the necessary CSS overrides to fix the modal.  
- By overriding, I just replaced `rem` units with `em` to make the modal’s sizing independent of the `<html>` font size.  
- Overrides are, where possible, css variables provided by dynamic. Where not, plain css rules.
- Set a `font-size` of `16px` on the modal's parent `<div>`, ensuring `em` units scale relative to this local size.  

## Tickets?

- [PLAT-2086](https://linear.app/fleekxyz/issue/PLAT-2086/authentication-modal-overflows-outside-the-screen-on-mobile)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [ ] Document filename is named after the slug
- [ ] You've reviewed spelling using a grammar checker
- [ ] For documentation, guides or references, you've tested the commands and steps
- [ ] You've done enough research before writing

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] The Components are escaping output (to prevent XSS)

## References?

Optionally, provide references such as links

## Preview?

### Before

<img width="429" alt="Screenshot 2025-02-06 at 18 20 59" src="https://github.com/user-attachments/assets/221b1b0d-5236-405f-8183-78043fce7eb4" />
<img width="429" alt="Screenshot 2025-02-06 at 18 21 12" src="https://github.com/user-attachments/assets/45bc81e5-585d-46f5-8607-d83f2697acdd" />


### After

<img width="429" alt="Screenshot 2025-02-06 at 18 20 46" src="https://github.com/user-attachments/assets/84a402c6-8682-4321-9935-850482a8db1f" />

<img width="429" alt="Screenshot 2025-02-06 at 18 21 15" src="https://github.com/user-attachments/assets/411cdd78-5d96-4fb4-a41f-406c5f083b19" />
