### PR TITLE
fix(dynamic): add missing css rule for text-button font-size

### DIFF
--- a/.changeset/fuzzy-monkeys-act.md
+++ b/.changeset/fuzzy-monkeys-act.md
@@ -1,0 +1,5 @@
+---
+"@fleek-platform/login-button": patch
+---
+
+Fixes re-send code button font-size and fixes LoginProvider not re-rendering on isLoading change

--- a/src/css/index.css
+++ b/src/css/index.css
@@ -71,3 +71,7 @@
   height: 1.5em;
   width: 1.5em;
 }
+
+.dynamic-shadow-dom .text-button {
+  font-size: 0.75em;
+}


### PR DESCRIPTION
## Why?

The override for "Re-send code link" font-size was missing.

## How?

- Added missing css rule.

## Tickets?

- [PLAT-2086](https://linear.app/fleekxyz/issue/PLAT-2086/authentication-modal-overflows-outside-the-screen-on-mobile)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [ ] Document filename is named after the slug
- [ ] You've reviewed spelling using a grammar checker
- [ ] For documentation, guides or references, you've tested the commands and steps
- [ ] You've done enough research before writing

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] The Components are escaping output (to prevent XSS)

## References?

Optionally, provide references such as links

## Preview?

### Before

<img width="426" alt="Screenshot 2025-02-07 at 12 32 58" src="https://github.com/user-attachments/assets/882645a1-d538-4b7a-83a5-441453ce2e52" />

### After

<img width="426" alt="Screenshot 2025-02-07 at 12 32 14" src="https://github.com/user-attachments/assets/cc1479de-5e2a-4141-bff1-e50e9f49f750" />

