### PR TITLE
fix(dynamic): add missing css overrides for login modal

### DIFF
--- a/.changeset/twelve-seas-hide.md
+++ b/.changeset/twelve-seas-hide.md
@@ -1,0 +1,5 @@
+---
+"@fleek-platform/login-button": patch
+---
+
+Add missing css overrides for login modal

--- a/src/css/index.css
+++ b/src/css/index.css
@@ -75,3 +75,39 @@
 .dynamic-shadow-dom .text-button {
   font-size: 0.75em;
 }
+
+.dynamic-shadow-dom .pin-input__input {
+  font-size: 1em;
+  height: 2.75em;
+  max-width: 2.75em;
+}
+
+.dynamic-shadow-dom .search-instead__container {
+  font-size: .75em;
+  line-height: 1em;
+  margin-top: 2.5em;
+  padding-bottom: 1em;
+}
+
+.dynamic-shadow-dom .search-icon__container {
+  height: 1em;
+  width: 1em;
+}
+
+.dynamic-shadow-dom .search__container {
+  gap: .625em;
+  height: 2.625em;
+  justify-content: space-between;
+  min-height: 2.25em;
+  padding-left: .75em;
+  padding-right: .75em;
+}
+
+.dynamic-shadow-dom .icon--size-mini {
+  height: 1.25em;
+  width: 1.25em;
+}
+
+.dynamic-shadow-dom .qr-code-wrapper__scan-issue-button {
+  font-size: .75em;
+}

--- a/src/css/index.css
+++ b/src/css/index.css
@@ -97,7 +97,6 @@
 .dynamic-shadow-dom .search__container {
   gap: .625em;
   height: 2.625em;
-  justify-content: space-between;
   min-height: 2.25em;
   padding-left: .75em;
   padding-right: .75em;


### PR DESCRIPTION
## Why?

Added missing css overrides for login modal.

## How?

- Added missing css overrides to css/index.css

## Tickets?

- [PLAT-2086](https://linear.app/fleekxyz/issue/PLAT-2086/authentication-modal-overflows-outside-the-screen-on-mobile)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [ ] Document filename is named after the slug
- [ ] You've reviewed spelling using a grammar checker
- [ ] For documentation, guides or references, you've tested the commands and steps
- [ ] You've done enough research before writing

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] The Components are escaping output (to prevent XSS)

## References?

Optionally, provide references such as links

## Preview?

### Before

<img width="462" alt="Screenshot 2025-02-07 at 18 06 16" src="https://github.com/user-attachments/assets/04fce3b6-d803-4c01-a0f6-984a1795a12e" />

### After

<img width="462" alt="Screenshot 2025-02-07 at 18 06 39" src="https://github.com/user-attachments/assets/35c3c732-1816-407b-b4d2-f3550814ae6d" />

