### PR TITLE
fix: 🐛 Generated local path in copy & paste command

### DIFF
--- a/.changeset/five-kings-allow.md
+++ b/.changeset/five-kings-allow.md
@@ -1,0 +1,5 @@
+---
+"@fleek-platform/login-button": patch
+---
+
+Amend generated local package pathname in copy and paste command

--- a/.scripts/generate_npm_package
+++ b/.scripts/generate_npm_package
@@ -22,7 +22,7 @@ fi
 
 package=$(echo "$filepath" | rev | cut -d '/' -f1 | rev)
 
-abs_filepath="$(pwd)/$filepath"
+abs_filepath="$(pwd)/$DEST_DIR/$filepath"
 
 echo "✅ Packaged successfully in $DEST_DIR/$package"
 echo "💡 Copy and paste the command to install in your project. You can use the universal npm in any project:"


### PR DESCRIPTION
## Why?

Generated local path in copy & paste command

## How?

- Adds missing `.install`

## Tickets?

- [PLAT-2238](https://linear.app/fleekxyz/issue/PLAT-2238/login-button-generated-local-path-in-copy-and-paste-command)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [ ] Document filename is named after the slug
- [ ] You've reviewed spelling using a grammar checker
- [ ] For documentation, guides or references, you've tested the commands and steps
- [ ] You've done enough research before writing

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] The Components are escaping output (to prevent XSS)

## References?

Optionally, provide references such as links

## Preview?

Optionally, provide the preview url here
