### PR TITLE
chore: 🤖 Extend session dismissal checkups

### DIFF
--- a/.changeset/long-lions-behave.md
+++ b/.changeset/long-lions-behave.md
@@ -1,0 +1,5 @@
+---
+"@fleek-platform/login-button": minor
+---
+
+Extend session dismissal check with cookie mismatching locals storage session details

--- a/src/providers/DynamicProvider.tsx
+++ b/src/providers/DynamicProvider.tsx
@@ -64,10 +64,13 @@ const validateUserSession = async ({
 
     const cookieAccessToken = cookies.get('accessToken');
 
-    if (cookieAccessToken !== accessToken) throw Error(`Expected ${truncateMiddle(accessToken)} but got ${typeof cookieAccessToken === 'string' ? truncateMiddle(cookieAccessToken) : typeof cookieAccessToken}`);
+    if (cookieAccessToken !== accessToken)
+      throw Error(
+        `Expected ${truncateMiddle(accessToken)} but got ${typeof cookieAccessToken === 'string' ? truncateMiddle(cookieAccessToken) : typeof cookieAccessToken}`,
+      );
 
     typeof onAuthenticationSuccess === 'function' && onAuthenticationSuccess();
-        
+
     return true;
   } catch (error) {
     console.error('Authentication validation failed:', error);
@@ -190,7 +193,7 @@ export const DynamicProvider: FC<DynamicProviderProps> = ({ children, graphqlApi
       onAuthenticationSuccess: () => {
         cookies.set('accessToken', accessToken);
         cookies.set('projectId', projectId);
-      }
+      },
     });
   }, [onLogout]);
 

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -108,6 +108,10 @@ export const useAuthStore = create<AuthStore>()(
             throw new Error('Failed to get access token');
           }
 
+          // TODO: Make a projectId validation against
+          // the accessToken projectId as it should match.
+          // On failure, throw error.
+
           const accessToken = res.data;
 
           set({

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -5,6 +5,7 @@ import { useConfigStore } from './configStore';
 import { getStoreName } from '../utils/store';
 import { decodeAccessToken } from '../utils/token';
 import type { UserProfile } from '@dynamic-labs/sdk-react-core';
+import { cookies } from '../utils/cookies';
 
 export type TriggerLoginModal = (open: boolean) => void;
 export type TriggerLogout = () => void;
@@ -69,8 +70,15 @@ export const useAuthStore = create<AuthStore>()(
           accessToken,
           projectId,
         });
+
+        cookies.set('accessToken', accessToken);
+        cookies.set('projectId', projectId);
       },
-      setAuthToken: (authToken: string) => set({ authToken }),
+      setAuthToken: (authToken: string) => {
+        set({ authToken });
+
+        cookies.set('authToken', authToken);
+      },
       setIsLoggingIn: (isLoggingIn: boolean) => set({ isLoggingIn }),
       setIsLoggedIn: (isLoggedIn: boolean) => set({ isLoggedIn }),
       reset: () => set(initialState),
@@ -100,11 +108,15 @@ export const useAuthStore = create<AuthStore>()(
             throw new Error('Failed to get access token');
           }
 
+          const accessToken = res.data;
+
           set({
-            accessToken: res.data,
+            accessToken,
             projectId,
             isLoggingIn: false,
           });
+          
+          cookies.set('accessToken', accessToken);
         } catch (err) {
           console.error('Failed to update access token:', err);
 

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -115,7 +115,7 @@ export const useAuthStore = create<AuthStore>()(
             projectId,
             isLoggingIn: false,
           });
-          
+
           cookies.set('accessToken', accessToken);
         } catch (err) {
           console.error('Failed to update access token:', err);

--- a/src/utils/token.ts
+++ b/src/utils/token.ts
@@ -16,13 +16,9 @@ export const decodeAccessToken = (accessToken: string) => {
   return projectId;
 };
 
-export const truncateMiddle = (
-  str: string, 
-  numOfChars: number = 3, 
-  ellipsis: string = '...'
-): string => {
-  const start = str.substring(0, numOfChars);  
+export const truncateMiddle = (str: string, numOfChars: number = 3, ellipsis: string = '...'): string => {
+  const start = str.substring(0, numOfChars);
   const end = str.slice(-numOfChars);
-  
+
   return `${start}${ellipsis}${end}`;
-}
+};

--- a/src/utils/token.ts
+++ b/src/utils/token.ts
@@ -15,3 +15,14 @@ export const decodeAccessToken = (accessToken: string) => {
 
   return projectId;
 };
+
+export const truncateMiddle = (
+  str: string, 
+  numOfChars: number = 3, 
+  ellipsis: string = '...'
+): string => {
+  const start = str.substring(0, numOfChars);  
+  const end = str.slice(-numOfChars);
+  
+  return `${start}${ellipsis}${end}`;
+}

--- a/src/utils/token.ts
+++ b/src/utils/token.ts
@@ -16,7 +16,7 @@ export const decodeAccessToken = (accessToken: string) => {
   return projectId;
 };
 
-export const truncateMiddle = (str: string, numOfChars: number = 3, ellipsis: string = '...'): string => {
+export const truncateMiddle = (str: string, numOfChars = 3, ellipsis = '...'): string => {
   const start = str.substring(0, numOfChars);
   const end = str.slice(-numOfChars);
 


### PR DESCRIPTION
## Why?

Currently, there's a case where a user who logs outinvalidates the   session) and goes to the Website finds that the  login button doesn't trigger the modal (Chrome).

⚠️ Related to https://github.com/FleekHQ/fleek/pull/3723
⚠️ Closed by https://github.com/fleek-platform/login-button/pull/24

## How?

- Extend session checkups to include validating localStorage state against cookie tokens
- Place cookie setter closer to store state handling

## Tickets?

- [PLAT-2312](https://linear.app/fleekxyz/issue/PLAT-2312/login-button-cross-session-dismissal-requires-a-further-invalidation)

## Contribution checklist?

- [ ] The commit messages are detailed
- [ ] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [ ] Document filename is named after the slug
- [ ] You've reviewed spelling using a grammar checker
- [ ] For documentation, guides or references, you've tested the commands and steps
- [ ] You've done enough research before writing

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] The Components are escaping output (to prevent XSS)

## References?

Optionally, provide references such as links

## Preview?

https://github.com/user-attachments/assets/cf58df4f-8c9a-40f2-9803-69cddedfb159


