### PR TITLE
feat(avatar): :sparkles: expose user avatar in the auth store

### DIFF
--- a/.changeset/sour-jars-jam.md
+++ b/.changeset/sour-jars-jam.md
@@ -1,0 +1,5 @@
+---
+"@fleek-platform/login-button": minor
+---
+
+expose user avatar from the auth store

--- a/package.json
+++ b/package.json
@@ -4,17 +4,10 @@
   "description": "A standalone login component with an embedded Dynamic modal that functions independently of host application.",
   "repository": "https://github.com/fleek-platform/login-button",
   "homepage": "https://github.com/fleek-platform/login-button",
-  "keywords": [
-    "fleek",
-    "auth",
-    "dynamic"
-  ],
+  "keywords": ["fleek", "auth", "dynamic"],
   "license": "MIT",
   "type": "module",
-  "files": [
-    "dist",
-    "src"
-  ],
+  "files": ["dist", "src"],
   "exports": {
     ".": {
       "import": "./dist/bundle.js",

--- a/src/api/graphql-client.ts
+++ b/src/api/graphql-client.ts
@@ -5,6 +5,13 @@
 export interface SessionDetails {
   accessToken: string;
   projectId: string | null;
+  user: {
+    avatar?: string;
+    email: string;
+    id: string;
+    username: string;
+    walletAddress?: string;
+  };
   __typename: 'SessionDetails';
 }
 
@@ -143,18 +150,25 @@ export const generateUserSessionDetails = async (
   graphqlApiUrl: string,
   authToken: string,
 ): Promise<ExecGraphQLOperationResult<SessionDetails>> =>
-  executeGraphQLOperation<{ data: { authToken: string } }, SessionDetails>(graphqlApiUrl, {
+  executeGraphQLOperation<{ data: { authToken: string; includeUserResponseData: boolean } }, SessionDetails>(graphqlApiUrl, {
     operationName: 'generateUserSessionDetails',
     query: `
       mutation generateUserSessionDetails($data: GenerateUserSessionDetailsDataInput!) {
         generateUserSessionDetails(data: $data) {
           accessToken
           projectId
+          user {
+            id
+            username
+            email
+            avatar
+            walletAddress
+            }
           __typename
         }
       }
     `,
-    variables: { data: { authToken } },
+    variables: { data: { authToken, includeUserResponseData: true } },
   });
 
 export const me = async (graphqlApiUrl: string, accessToken: string): Promise<ExecGraphQLOperationResult<SessionDetails>> =>

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -4,8 +4,13 @@ import { loginWithDynamic } from '../api/graphql-client';
 import { useConfigStore } from './configStore';
 import { getStoreName } from '../utils/store';
 import { decodeAccessToken } from '../utils/token';
-import type { UserProfile } from '@dynamic-labs/sdk-react-core';
+import type { UserProfile as DynamicUserProfile } from '@dynamic-labs/sdk-react-core';
 import { cookies } from '../utils/cookies';
+
+export type UserProfile = DynamicUserProfile & {
+  avatar?: string;
+  username?: string;
+};
 
 export type TriggerLoginModal = (open: boolean) => void;
 export type TriggerLogout = () => void;


### PR DESCRIPTION
## Why?

We need to expose the user avatar to use it in the apps that instantiate this hook

## How?

- "Piggybacked" on the already existent `/me` call. This request happens in a function called `validateUserSession` which doesn't look like a good place for this.

- The other option would be to do this in a separate space by triggering another `/me` request.

## Tickets?

- [PLAT-2251](https://linear.app/fleekxyz/issue/PLAT-2251/agent-chat-interface)

## Contribution checklist?

- [ ] The commit messages are detailed
- [ ] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [ ] Document filename is named after the slug
- [ ] You've reviewed spelling using a grammar checker
- [ ] For documentation, guides or references, you've tested the commands and steps
- [ ] You've done enough research before writing

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] The Components are escaping output (to prevent XSS)

## References?

Optionally, provide references such as links

## Preview?

Optionally, provide the preview url here
