### PR TITLE
chore: 🤖 Extend session dismissal checkups (clear login-button items cookie only)

### DIFF
--- a/.changeset/long-lions-behave.md
+++ b/.changeset/long-lions-behave.md
@@ -2,4 +2,4 @@
 "@fleek-platform/login-button": minor
 ---
 
-Enhance Session Dismissal checks by comparing cookie and Local Storage session details
+Enhance session dismissal checks by clearing session on faulty data, e.g. unknown project id, missing cookie access token

--- a/.changeset/long-lions-behave.md
+++ b/.changeset/long-lions-behave.md
@@ -2,4 +2,4 @@
 "@fleek-platform/login-button": minor
 ---
 
-Extend session dismissal check with cookie mismatching locals storage session details
+Enhance Session Dismissal checks by comparing cookie and Local Storage session details

--- a/.changeset/long-lions-behave.md
+++ b/.changeset/long-lions-behave.md
@@ -1,0 +1,5 @@
+---
+"@fleek-platform/login-button": minor
+---
+
+Extend session dismissal check with cookie mismatching locals storage session details

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fleek-platform/login-button",
-  "version": "2.2.0-dev.233",
+  "version": "2.2.0",
   "description": "A standalone login component with an embedded Dynamic modal that functions independently of host application.",
   "repository": "https://github.com/fleek-platform/login-button",
   "homepage": "https://github.com/fleek-platform/login-button",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fleek-platform/login-button",
-  "version": "2.2.0",
+  "version": "2.2.0-dev.233",
   "description": "A standalone login component with an embedded Dynamic modal that functions independently of host application.",
   "repository": "https://github.com/fleek-platform/login-button",
   "homepage": "https://github.com/fleek-platform/login-button",
@@ -42,6 +42,7 @@
     "@dynamic-labs/ethereum": "3.9.2",
     "@dynamic-labs/sdk-react-core": "3.9.2",
     "@fleek-platform/utils-token": "^0.2.2",
+    "@types/lodash-es": "^4.17.12",
     "dotenv": "^16.4.7",
     "lodash-es": "^4.17.21",
     "react": "^18.3.1",
@@ -52,7 +53,6 @@
   "devDependencies": {
     "@biomejs/biome": "^1.8.3",
     "@changesets/cli": "^2.27.9",
-    "@types/lodash-es": "^4.17.12",
     "@types/luxon": "^3.4.2",
     "@types/node": "^20",
     "@types/react": "^18.0.9",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@dynamic-labs/sdk-react-core": "3.9.2",
     "@fleek-platform/utils-token": "^0.2.2",
     "dotenv": "^16.4.7",
+    "lodash-es": "^4.17.21",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "viem": "^2.21.55",
@@ -51,6 +52,7 @@
   "devDependencies": {
     "@biomejs/biome": "^1.8.3",
     "@changesets/cli": "^2.27.9",
+    "@types/lodash-es": "^4.17.12",
     "@types/luxon": "^3.4.2",
     "@types/node": "^20",
     "@types/react": "^18.0.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       dotenv:
         specifier: ^16.4.7
         version: 16.4.7
+      lodash-es:
+        specifier: ^4.17.21
+        version: 4.17.21
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -39,6 +42,9 @@ importers:
       '@changesets/cli':
         specifier: ^2.27.9
         version: 2.27.12
+      '@types/lodash-es':
+        specifier: ^4.17.12
+        version: 4.17.12
       '@types/luxon':
         specifier: ^3.4.2
         version: 3.4.2
@@ -1665,6 +1671,9 @@ packages:
 
   '@types/istanbul-reports@3.0.4':
     resolution: {integrity: sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==}
+
+  '@types/lodash-es@4.17.12':
+    resolution: {integrity: sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==}
 
   '@types/lodash@4.17.15':
     resolution: {integrity: sha512-w/P33JFeySuhN6JLkysYUK2gEmy9kHHFN7E8ro0tkfmlDOgxBDzWEZ/J8cWA+fHqFevpswDTFZnDx+R9lbL6xw==}
@@ -6381,6 +6390,10 @@ snapshots:
   '@types/istanbul-reports@3.0.4':
     dependencies:
       '@types/istanbul-lib-report': 3.0.3
+
+  '@types/lodash-es@4.17.12':
+    dependencies:
+      '@types/lodash': 4.17.15
 
   '@types/lodash@4.17.15': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@fleek-platform/utils-token':
         specifier: ^0.2.2
         version: 0.2.3
+      '@types/lodash-es':
+        specifier: ^4.17.12
+        version: 4.17.12
       dotenv:
         specifier: ^16.4.7
         version: 16.4.7
@@ -42,9 +45,6 @@ importers:
       '@changesets/cli':
         specifier: ^2.27.9
         version: 2.27.12
-      '@types/lodash-es':
-        specifier: ^4.17.12
-        version: 4.17.12
       '@types/luxon':
         specifier: ^3.4.2
         version: 3.4.2
@@ -1984,7 +1984,6 @@ packages:
 
   bun@1.2.2:
     resolution: {integrity: sha512-RUc8uVVTw8WoASUzXaEQJR1s7mnwoHm3P871qBUIqSaoOpuwcU+bSVX151/xoqDwnyv38SjOX7yQ3oO0IeT73g==}
-    cpu: [arm64, x64, aarch64]
     os: [darwin, linux, win32]
     hasBin: true
 

--- a/src/providers/DynamicProvider.tsx
+++ b/src/providers/DynamicProvider.tsx
@@ -117,24 +117,22 @@ const validateUserSession = async ({
   onAuthenticationFailure: () => void;
   onAuthenticationSuccess?: () => void;
   reinitializeSdk?: () => void;
-}): Promise<boolean> => {
-  if (authenticating) return false;
-  
+}): Promise<boolean> => {  
   try {
     const cookieAuthToken = cookies.get('authToken');
     const cookieAccessToken = cookies.get('accessToken');
-    const _localStorageAuthToken = localStorage?.dynamic_authentication_token;
+
+    const hasAuthenticationInProgress = authenticating;
 
     // An accessToken is computed on authentication process.
     // If a cookieAccess token's missing we'll assume
     // that the authentication is processing returning truthy
     // and only consider authToken matching
-    // const hasMatchingTokens = (cookieAuthToken === _localStorageAuthToken) && (!!cookieAccessToken && !!accessToken ? cookieAccessToken === accessToken : true);
-    const hasMatchingTokens = (cookieAuthToken === _localStorageAuthToken) && (cookieAccessToken === accessToken) && !authenticating;
+    const hasMatchingTokens = (cookieAuthToken === localStorageAuthToken) && (cookieAccessToken === accessToken) && !authenticating;
 
     // TODO: Maybe use the https://docs.dynamic.xyz/react-sdk/utilities/getauthtoken#getauthtoken
     // to avoid using localStorage directly
-    const hasDynamicLocalStorageItems = !!hasLocalStorageItems('dynamic') && !!_localStorageAuthToken;
+    const hasDynamicLocalStorageItems = !!hasLocalStorageItems('dynamic') && !!localStorageAuthToken;
 
     const hasDynamicAuthWithoutAccessTokens = !!hasDynamicLocalStorageItems && (!cookieAuthToken || !cookieAccessToken);
 
@@ -142,7 +140,8 @@ const validateUserSession = async ({
 
     const hasMatchingAcessTokenInCookie = !!accessToken && accessToken === cookieAccessToken;
 
-    if (hasMatchingTokens) return true;
+
+    if (hasAuthenticationInProgress  || hasMatchingTokens) return true;
 
     if (hasDynamicAuthWithoutAccessTokens) throw Error('Found missing Dynamic cookie paired tokens');
 

--- a/src/providers/DynamicProvider.tsx
+++ b/src/providers/DynamicProvider.tsx
@@ -23,6 +23,12 @@ type DynamicUtilsProps = {
   setReinitializeSdk: (callback: ReinitializeSdk) => void;
 };
 
+type HasDataCommonError = {
+  error: {
+    type: string;
+  },
+};
+
 const DynamicUtils = ({
   onTriggerLoginModal,
   onTriggerLogout,
@@ -81,10 +87,8 @@ const DynamicUtils = ({
 
     debouncedValidation();
 
-    (window as any).reinitializeSdk = reinitializeSdk;
-
     return () => debouncedValidation.cancel();
-  }, [accessToken, graphqlApiUrl]);
+  }, [accessToken, graphqlApiUrl, localStorageAuthToken, onLogout, reinitializeSdk]);
 
   return null;
 };
@@ -147,8 +151,8 @@ const validateUserSession = async ({
     // e.g. it might cause to call `onAuthenticationFailure`
     // which would clear the user session details wrongly
     const hasNetworkError =
-      (!hasMeResult.success && (hasMeResult as any)?.error?.type === 'NETWORK_ERROR') ||
-      (!hasProjectResult.success && (hasProjectResult as any)?.error?.type === 'NETWORK_ERROR');
+      (!hasMeResult.success && (hasMeResult as HasDataCommonError)?.error?.type === 'NETWORK_ERROR') ||
+      (!hasProjectResult.success && (hasProjectResult as HasDataCommonError)?.error?.type === 'NETWORK_ERROR');
 
     if (hasNetworkError) return false;
 

--- a/src/providers/DynamicProvider.tsx
+++ b/src/providers/DynamicProvider.tsx
@@ -64,10 +64,13 @@ const validateUserSession = async ({
 
     const cookieAccessToken = cookies.get('accessToken');
 
-    if (cookieAccessToken !== accessToken) throw Error(`Expected ${truncateMiddle(accessToken)} but got ${typeof cookieAccessToken === 'string' ? truncateMiddle(cookieAccessToken) : typeof cookieAccessToken}`);
+    if (cookieAccessToken !== accessToken)
+      throw Error(
+        `Expected ${truncateMiddle(accessToken)} but got ${typeof cookieAccessToken === 'string' ? truncateMiddle(cookieAccessToken) : typeof cookieAccessToken}`,
+      );
 
     typeof onAuthenticationSuccess === 'function' && onAuthenticationSuccess();
-        
+
     return true;
   } catch (error) {
     console.error('Authentication validation failed:', error);
@@ -190,7 +193,7 @@ export const DynamicProvider: FC<DynamicProviderProps> = ({ children, graphqlApi
       onAuthenticationSuccess: () => {
         cookies.set('accessToken', accessToken);
         cookies.set('projectId', projectId);
-      }
+      },
     });
   }, [onLogout]);
 

--- a/src/providers/DynamicProvider.tsx
+++ b/src/providers/DynamicProvider.tsx
@@ -60,20 +60,12 @@ const validateUserSession = async ({
 
     const hasDynamicLocalStorageItems = hasLocalStorageItems('dynamic');
 
-    const hasDynamicAuthWithoutAccessTokens =
-      hasDynamicLocalStorageItems
-      && (!cookieAuthToken || !cookieAccessToken);
+    const hasDynamicAuthWithoutAccessTokens = hasDynamicLocalStorageItems && (!cookieAuthToken || !cookieAccessToken);
 
-    const hasDynamicAuthWithAccessTokens =
-      hasDynamicLocalStorageItems
-      && accessToken
-      && cookieAuthToken
-      && cookieAccessToken;
+    const hasDynamicAuthWithAccessTokens = hasDynamicLocalStorageItems && accessToken && cookieAuthToken && cookieAccessToken;
 
-    const hasMatchingAcessTokenInCookie =
-      accessToken
-      && (accessToken === cookieAccessToken);
-    
+    const hasMatchingAcessTokenInCookie = accessToken && accessToken === cookieAccessToken;
+
     if (hasDynamicAuthWithoutAccessTokens) {
       cookies.reset();
       clearUserSessionKeys();
@@ -96,9 +88,7 @@ const validateUserSession = async ({
 
     const { success: hasProject } = await project(graphqlApiUrl, cookieAccessToken, projectId);
 
-    const hasUserSessionExpectedDetails =
-      hasMe
-      && hasProject
+    const hasUserSessionExpectedDetails = hasMe && hasProject;
 
     if (!hasUserSessionExpectedDetails) throw Error('Unexpected user session details');
 
@@ -204,7 +194,7 @@ export const DynamicProvider: FC<DynamicProviderProps> = ({ children, graphqlApi
 
   useEffect(() => {
     if (!graphqlApiUrl) return;
-    
+
     // Validates the user session sometime in the future.
     // If found faulty, it should clear the user session
     // e.g. user session clear/logout by dashboard.

--- a/src/providers/DynamicProvider.tsx
+++ b/src/providers/DynamicProvider.tsx
@@ -23,7 +23,14 @@ type DynamicUtilsProps = {
   setReinitializeSdk: (callback: ReinitializeSdk) => void;
 };
 
-const DynamicUtils = ({ onTriggerLoginModal, onTriggerLogout, graphqlApiUrl, accessToken, onLogout, setReinitializeSdk }: DynamicUtilsProps) => {
+const DynamicUtils = ({
+  onTriggerLoginModal,
+  onTriggerLogout,
+  graphqlApiUrl,
+  accessToken,
+  onLogout,
+  setReinitializeSdk,
+}: DynamicUtilsProps) => {
   const { sdkHasLoaded, setShowAuthFlow, handleLogOut } = useDynamicContext();
   const reinitializeSdk = useReinitialize();
   const localStorageAuthToken = getAuthToken();
@@ -42,7 +49,7 @@ const DynamicUtils = ({ onTriggerLoginModal, onTriggerLogout, graphqlApiUrl, acc
 
   useEffect(() => {
     if (!reinitializeSdk) return;
-    
+
     setReinitializeSdk(reinitializeSdk);
   }, [setReinitializeSdk, reinitializeSdk]);
 
@@ -116,10 +123,9 @@ const validateUserSession = async ({
 
     const hasDynamicAuthWithAccessTokens = !!hasDynamicLocalStorageItems && !!accessToken && !!cookieAuthToken && !!cookieAccessToken;
 
-    const hasMatchingAcessTokenInCookie = !!accessToken && (accessToken === cookieAccessToken);
+    const hasMatchingAcessTokenInCookie = !!accessToken && accessToken === cookieAccessToken;
 
-    if (hasDynamicAuthWithoutAccessTokens) 
-      throw Error('Found missing Dynamic cookie paired tokens');
+    if (hasDynamicAuthWithoutAccessTokens) throw Error('Found missing Dynamic cookie paired tokens');
 
     if (!hasDynamicAuthWithAccessTokens || !cookieAccessToken) return false;
 
@@ -141,16 +147,14 @@ const validateUserSession = async ({
     // e.g. it might cause to call `onAuthenticationFailure`
     // which would clear the user session details wrongly
     const hasNetworkError =
-      !hasMeResult.success && (hasMeResult as any)?.error?.type === 'NETWORK_ERROR' ||
-      !hasProjectResult.success && (hasProjectResult as any)?.error?.type === 'NETWORK_ERROR';
+      (!hasMeResult.success && (hasMeResult as any)?.error?.type === 'NETWORK_ERROR') ||
+      (!hasProjectResult.success && (hasProjectResult as any)?.error?.type === 'NETWORK_ERROR');
 
-    if (hasNetworkError) 
-      return false;
-    
+    if (hasNetworkError) return false;
 
     const hasMe = !!hasMeResult.success;
     const hasProject = !!hasProjectResult.success;
-    
+
     const hasUserSessionExpectedDetails = hasMe && hasProject;
 
     if (!hasUserSessionExpectedDetails) throw Error('Unexpected user session details');

--- a/src/providers/DynamicProvider.tsx
+++ b/src/providers/DynamicProvider.tsx
@@ -117,14 +117,14 @@ const validateUserSession = async ({
   onAuthenticationFailure: () => void;
   onAuthenticationSuccess?: () => void;
   reinitializeSdk?: () => void;
-}): Promise<boolean> => {  
+}): Promise<boolean> => {
   try {
     const cookieAuthToken = cookies.get('authToken');
     const cookieAccessToken = cookies.get('accessToken');
 
     const hasAuthenticationInProgress = authenticating;
 
-    const hasMatchingTokens = !authenticating && (cookieAuthToken === localStorageAuthToken) && (cookieAccessToken === accessToken);
+    const hasMatchingTokens = !authenticating && cookieAuthToken === localStorageAuthToken && cookieAccessToken === accessToken;
 
     const hasDynamicLocalStorageItems = !!hasLocalStorageItems('dynamic') && !!localStorageAuthToken;
 
@@ -224,8 +224,7 @@ export const DynamicProvider: FC<DynamicProviderProps> = ({ children, graphqlApi
     window.location.reload();
   };
 
-  const onAuthInit = () => 
-    setAuthenticating(true);
+  const onAuthInit = () => setAuthenticating(true);
 
   // TODO: Remove useCallback to inspect re-triggers
   const onAuthSuccess = useCallback(

--- a/src/providers/DynamicProvider.tsx
+++ b/src/providers/DynamicProvider.tsx
@@ -62,7 +62,7 @@ const DynamicUtils = ({
       reinitializeSdk,
       onAuthenticationFailure: () => onLogout(),
     });
-  }, [accessToken, localStorageAuthToken, graphqlApiUrl, reinitializeSdk, onLogout]);
+  }, [accessToken, authenticating, localStorageAuthToken, graphqlApiUrl, reinitializeSdk, onLogout]);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies(setShowAuthFlow): causes infinite render, probably not memoized
   useEffect(() => {
@@ -90,7 +90,7 @@ const DynamicUtils = ({
     debouncedValidation();
 
     return () => debouncedValidation.cancel();
-  }, [authenticating, graphqlApiUrl, localStorageAuthToken, validateUserSessionMemoized]);
+  }, [authenticating, graphqlApiUrl, validateUserSessionMemoized]);
 
   return null;
 };

--- a/src/providers/DynamicProvider.tsx
+++ b/src/providers/DynamicProvider.tsx
@@ -220,7 +220,14 @@ export const DynamicProvider: FC<DynamicProviderProps> = ({ children, graphqlApi
     // Clear critical stores
     clearUserSessionKeys();
     setIsLoggedIn(false);
+
     typeof reinitializeSdk === 'function' && reinitializeSdk();
+
+    // TODO: The following can be dismiss since
+    // introducing reinitializeSdk. But, a logout
+    // processing state is required.
+    // For the moment, we'll flush the session
+    // by refreshing the page.
     window.location.reload();
   };
 

--- a/src/providers/DynamicProvider.tsx
+++ b/src/providers/DynamicProvider.tsx
@@ -210,7 +210,7 @@ export const DynamicProvider: FC<DynamicProviderProps> = ({ children, graphqlApi
       graphqlApiUrl,
       onAuthenticationFailure: () => onLogout(),
     });
-  }, [graphqlApiUrl]);
+  }, [accessToken, graphqlApiUrl, onLogout]);
 
   const settings = {
     environmentId: dynamicEnvironmentId,

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -108,6 +108,10 @@ export const useAuthStore = create<AuthStore>()(
             throw new Error('Failed to get access token');
           }
 
+          // TODO: Make a projectId validation against
+          // the accessToken projectId as it should match.
+          // On failure, throw error.
+
           const accessToken = res.data;
 
           set({

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -5,6 +5,7 @@ import { useConfigStore } from './configStore';
 import { getStoreName } from '../utils/store';
 import { decodeAccessToken } from '../utils/token';
 import type { UserProfile } from '@dynamic-labs/sdk-react-core';
+import { cookies } from '../utils/cookies';
 
 export type TriggerLoginModal = (open: boolean) => void;
 export type TriggerLogout = () => void;
@@ -69,8 +70,15 @@ export const useAuthStore = create<AuthStore>()(
           accessToken,
           projectId,
         });
+
+        cookies.set('accessToken', accessToken);
+        cookies.set('projectId', projectId);
       },
-      setAuthToken: (authToken: string) => set({ authToken }),
+      setAuthToken: (authToken: string) => {
+        set({ authToken });
+
+        cookies.set('authToken', authToken);
+      },
       setIsLoggingIn: (isLoggingIn: boolean) => set({ isLoggingIn }),
       setIsLoggedIn: (isLoggedIn: boolean) => set({ isLoggedIn }),
       reset: () => set(initialState),
@@ -100,11 +108,15 @@ export const useAuthStore = create<AuthStore>()(
             throw new Error('Failed to get access token');
           }
 
+          const accessToken = res.data;
+
           set({
-            accessToken: res.data,
+            accessToken,
             projectId,
             isLoggingIn: false,
           });
+          
+          cookies.set('accessToken', accessToken);
         } catch (err) {
           console.error('Failed to update access token:', err);
 

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -9,6 +9,7 @@ import { cookies } from '../utils/cookies';
 
 export type TriggerLoginModal = (open: boolean) => void;
 export type TriggerLogout = () => void;
+export type ReinitializeSdk = () => void;
 
 const name = getStoreName('login-button');
 
@@ -22,12 +23,14 @@ export interface AuthStore {
   userProfile?: UserProfile;
   triggerLoginModal?: TriggerLoginModal;
   triggerLogout?: TriggerLogout;
+  reinitializeSdk?: ReinitializeSdk;
   setAccessToken: (value: string) => void;
   setAuthToken: (value: string) => void;
   setIsLoggingIn: (isLoggingIn: boolean) => void;
   setIsLoggedIn: (isLoggedIn: boolean) => void;
   setTriggerLogout: (triggerLogout: TriggerLogout) => void;
   setTriggerLoginModal: (callback: TriggerLoginModal) => void;
+  setReinitializeSdk: (callback: ReinitializeSdk) => void;
   updateAccessTokenByProjectId: (projectId: string) => Promise<void>;
   reset: () => void;
   setIsNewUser: (isNewUser: boolean) => void;
@@ -138,4 +141,5 @@ export const useAuthStore = create<AuthStore>()((set, get) => ({
   setTriggerLoginModal: (triggerLoginModal: TriggerLoginModal) => set({ triggerLoginModal }),
   setTriggerLogout: (triggerLogout: TriggerLogout) => set({ triggerLogout }),
   setProjectId: (projectId: string) => set({ projectId }),
+  setReinitializeSdk: (reinitializeSdk: ReinitializeSdk) => set({ reinitializeSdk }),
 }));

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -106,11 +106,13 @@ export const useAuthStore = create<AuthStore>()((set, get) => ({
         throw new Error('Failed to get access token');
       }
 
-      // TODO: Make a projectId validation against
-      // the accessToken projectId as it should match.
-      // On failure, throw error.
-
       const accessToken = res.data;
+
+      const decodedProjectId = decodeAccessToken(accessToken);
+
+      if (!decodedProjectId) throw Error(`Expected a Project identifier but got ${projectId || typeof projectId}`);
+
+      if (decodedProjectId !== projectId) throw Error(`Found a project mismatch`);
 
       set({
         accessToken,

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -124,7 +124,6 @@ export const useAuthStore = create<AuthStore>()((set, get) => ({
     } catch (err) {
       console.error('Failed to update access token:', err);
 
-      // TODO: Shouldn't this be set as spread of initialState obj?
       set({
         isLoggingIn: false,
         accessToken: '',

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -112,7 +112,7 @@ export const useAuthStore = create<AuthStore>()((set, get) => ({
 
       if (!decodedProjectId) throw Error(`Expected a Project identifier but got ${projectId || typeof projectId}`);
 
-      if (decodedProjectId !== projectId) throw Error(`Found a project mismatch`);
+      if (decodedProjectId !== projectId) throw Error('Found a project mismatch');
 
       set({
         accessToken,

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -60,7 +60,6 @@ export const initialState: AuthState = {
 };
 
 export const useAuthStore = create<AuthStore>()(
-  persist(
     (set, get) => ({
       ...initialState,
       setAccessToken: (accessToken: string) => {
@@ -139,18 +138,6 @@ export const useAuthStore = create<AuthStore>()(
       setTriggerLoginModal: (triggerLoginModal: TriggerLoginModal) => set({ triggerLoginModal }),
       setTriggerLogout: (triggerLogout: TriggerLogout) => set({ triggerLogout }),
       setProjectId: (projectId: string) => set({ projectId }),
-    }),
-    {
-      name,
-      storage: createJSONStorage(() => localStorage),
-      // Persist only selected keys
-      partialize: ({ accessToken, authToken, projectId, isNewUser, userProfile }) => ({
-        userProfile,
-        accessToken,
-        authToken,
-        projectId,
-        isNewUser,
-      }),
-    },
+    }
   ),
 );

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -16,6 +16,7 @@ const name = getStoreName('login-button');
 export interface AuthStore {
   accessToken: string;
   authToken: string;
+  authenticating: boolean;
   isNewUser: boolean;
   projectId: string;
   isLoggedIn: boolean;
@@ -36,12 +37,14 @@ export interface AuthStore {
   setIsNewUser: (isNewUser: boolean) => void;
   setUserProfile: (userProfile: UserProfile) => void;
   setProjectId: (projectId: string) => void;
+  setAuthenticating: (authenticating: boolean) => void;
 }
 
 export interface AuthState
   extends Pick<
     AuthStore,
     | 'accessToken'
+    | 'authenticating'
     | 'authToken'
     | 'projectId'
     | 'isNewUser'
@@ -54,6 +57,7 @@ export interface AuthState
 
 export const initialState: AuthState = {
   accessToken: '',
+  authenticating: false,
   authToken: '',
   projectId: '',
   isNewUser: false,
@@ -142,4 +146,5 @@ export const useAuthStore = create<AuthStore>()((set, get) => ({
   setTriggerLogout: (triggerLogout: TriggerLogout) => set({ triggerLogout }),
   setProjectId: (projectId: string) => set({ projectId }),
   setReinitializeSdk: (reinitializeSdk: ReinitializeSdk) => set({ reinitializeSdk }),
+  setAuthenticating: (authenticating: boolean) => set({ authenticating })
 }));

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -146,5 +146,5 @@ export const useAuthStore = create<AuthStore>()((set, get) => ({
   setTriggerLogout: (triggerLogout: TriggerLogout) => set({ triggerLogout }),
   setProjectId: (projectId: string) => set({ projectId }),
   setReinitializeSdk: (reinitializeSdk: ReinitializeSdk) => set({ reinitializeSdk }),
-  setAuthenticating: (authenticating: boolean) => set({ authenticating })
+  setAuthenticating: (authenticating: boolean) => set({ authenticating }),
 }));

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -59,85 +59,82 @@ export const initialState: AuthState = {
   userProfile: undefined,
 };
 
-export const useAuthStore = create<AuthStore>()(
-    (set, get) => ({
-      ...initialState,
-      setAccessToken: (accessToken: string) => {
-        const projectId = decodeAccessToken(accessToken);
+export const useAuthStore = create<AuthStore>()((set, get) => ({
+  ...initialState,
+  setAccessToken: (accessToken: string) => {
+    const projectId = decodeAccessToken(accessToken);
 
-        set({
-          accessToken,
-          projectId,
-        });
+    set({
+      accessToken,
+      projectId,
+    });
 
-        cookies.set('accessToken', accessToken);
-        cookies.set('projectId', projectId);
-      },
-      setAuthToken: (authToken: string) => {
-        set({ authToken });
+    cookies.set('accessToken', accessToken);
+    cookies.set('projectId', projectId);
+  },
+  setAuthToken: (authToken: string) => {
+    set({ authToken });
 
-        cookies.set('authToken', authToken);
-      },
-      setIsLoggingIn: (isLoggingIn: boolean) => set({ isLoggingIn }),
-      setIsLoggedIn: (isLoggedIn: boolean) => set({ isLoggedIn }),
-      reset: () => set(initialState),
-      updateAccessTokenByProjectId: async (projectId: string) => {
-        try {
-          set({ isLoggingIn: true });
+    cookies.set('authToken', authToken);
+  },
+  setIsLoggingIn: (isLoggingIn: boolean) => set({ isLoggingIn }),
+  setIsLoggedIn: (isLoggedIn: boolean) => set({ isLoggedIn }),
+  reset: () => set(initialState),
+  updateAccessTokenByProjectId: async (projectId: string) => {
+    try {
+      set({ isLoggingIn: true });
 
-          const { authToken } = get();
+      const { authToken } = get();
 
-          const { graphqlApiUrl } = useConfigStore.getState();
+      const { graphqlApiUrl } = useConfigStore.getState();
 
-          if (!authToken) {
-            throw new Error('Auth token is required to update access token');
-          }
+      if (!authToken) {
+        throw new Error('Auth token is required to update access token');
+      }
 
-          if (!graphqlApiUrl) {
-            throw new Error('GraphQL API URL is required to update access token');
-          }
+      if (!graphqlApiUrl) {
+        throw new Error('GraphQL API URL is required to update access token');
+      }
 
-          const res = await loginWithDynamic(graphqlApiUrl, authToken, projectId);
+      const res = await loginWithDynamic(graphqlApiUrl, authToken, projectId);
 
-          if (!res.success) {
-            throw new Error(res.error.message);
-          }
+      if (!res.success) {
+        throw new Error(res.error.message);
+      }
 
-          if (!res.data) {
-            throw new Error('Failed to get access token');
-          }
+      if (!res.data) {
+        throw new Error('Failed to get access token');
+      }
 
-          // TODO: Make a projectId validation against
-          // the accessToken projectId as it should match.
-          // On failure, throw error.
+      // TODO: Make a projectId validation against
+      // the accessToken projectId as it should match.
+      // On failure, throw error.
 
-          const accessToken = res.data;
+      const accessToken = res.data;
 
-          set({
-            accessToken,
-            projectId,
-            isLoggingIn: false,
-          });
+      set({
+        accessToken,
+        projectId,
+        isLoggingIn: false,
+      });
 
-          cookies.set('accessToken', accessToken);
-        } catch (err) {
-          console.error('Failed to update access token:', err);
+      cookies.set('accessToken', accessToken);
+    } catch (err) {
+      console.error('Failed to update access token:', err);
 
-          // TODO: Shouldn't this be set as spread of initialState obj?
-          set({
-            isLoggingIn: false,
-            accessToken: '',
-            projectId: '',
-          });
+      // TODO: Shouldn't this be set as spread of initialState obj?
+      set({
+        isLoggingIn: false,
+        accessToken: '',
+        projectId: '',
+      });
 
-          throw err;
-        }
-      },
-      setUserProfile: (userProfile: UserProfile) => set({ userProfile }),
-      setIsNewUser: (isNewUser: boolean) => set({ isNewUser }),
-      setTriggerLoginModal: (triggerLoginModal: TriggerLoginModal) => set({ triggerLoginModal }),
-      setTriggerLogout: (triggerLogout: TriggerLogout) => set({ triggerLogout }),
-      setProjectId: (projectId: string) => set({ projectId }),
+      throw err;
     }
-  ),
-);
+  },
+  setUserProfile: (userProfile: UserProfile) => set({ userProfile }),
+  setIsNewUser: (isNewUser: boolean) => set({ isNewUser }),
+  setTriggerLoginModal: (triggerLoginModal: TriggerLoginModal) => set({ triggerLoginModal }),
+  setTriggerLogout: (triggerLogout: TriggerLogout) => set({ triggerLogout }),
+  setProjectId: (projectId: string) => set({ projectId }),
+}));

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -115,7 +115,7 @@ export const useAuthStore = create<AuthStore>()(
             projectId,
             isLoggingIn: false,
           });
-          
+
           cookies.set('accessToken', accessToken);
         } catch (err) {
           console.error('Failed to update access token:', err);

--- a/src/utils/browser.ts
+++ b/src/utils/browser.ts
@@ -36,4 +36,4 @@ export const clearUserSessionKeys = () => {
   for (const item of userSessionLocalStorageKeys) {
     clearStorageByMatchTerm(item);
   }
-}
+};

--- a/src/utils/browser.ts
+++ b/src/utils/browser.ts
@@ -1,10 +1,6 @@
 export const isClient = typeof window !== 'undefined';
 
-// TODO: The `navigation-store` is set in agents-ui
-// this have to be namespaced and prefixed by `fleek-xyz-`
-// e.g. rename as `fleek-xyz-navigation-store`
-const temp = 'navigation-store';
-const userSessionLocalStorageKeys = ['dynamic', 'wagmi', 'fleek-xyz', temp];
+const userSessionLocalStorageKeys = ['dynamic', 'wagmi', 'fleek-xyz'];
 
 export const clearStorageByMatchTerm = (term: string) => {
   try {

--- a/src/utils/browser.ts
+++ b/src/utils/browser.ts
@@ -1,10 +1,16 @@
 export const isClient = typeof window !== 'undefined';
 
+// TODO: The `navigation-store` is set in agents-ui
+// this have to be namespaced and prefixed by `fleek-xyz-`
+// e.g. rename as `fleek-xyz-navigation-store`
+const temp = 'navigation-store';
+const userSessionLocalStorageKeys = ['dynamic', 'wagmi', 'fleek-xyz', temp];
+
 export const clearStorageByMatchTerm = (term: string) => {
   try {
     for (const key in localStorage) {
       try {
-        if (key.toLowerCase().includes(term)) {
+        if (key.toLowerCase().startsWith(term)) {
           localStorage.removeItem(key);
         }
       } catch (e) {
@@ -14,7 +20,7 @@ export const clearStorageByMatchTerm = (term: string) => {
 
     for (const key in sessionStorage) {
       try {
-        if (key.toLowerCase().includes(term)) {
+        if (key.toLowerCase().startsWith(term)) {
           sessionStorage.removeItem(key);
         }
       } catch (e) {
@@ -25,3 +31,9 @@ export const clearStorageByMatchTerm = (term: string) => {
     console.error('Failed to clear storage due to an error', error);
   }
 };
+
+export const clearUserSessionKeys = () => {
+  for (const item of userSessionLocalStorageKeys) {
+    clearStorageByMatchTerm(item);
+  }
+}

--- a/src/utils/store.ts
+++ b/src/utils/store.ts
@@ -3,3 +3,17 @@ type STORE_NAME = 'login-button' | 'config';
 const CONFIG_NAMESPACE = 'fleek-xyz-login-btn';
 
 export const getStoreName = (name: STORE_NAME) => `${CONFIG_NAMESPACE}-${name}-store`;
+
+export const hasLocalStorageItems = (term: string) => {
+  try {
+    if (typeof localStorage === 'undefined') {
+      console.warn('localStorage is not available in this environment');
+      return false;
+    }
+    
+    return Object.keys(localStorage).some(key => key.startsWith(term));
+  } catch (error) {
+    console.error('Failed to compute localStorage', error);
+    return false;
+  }
+};

--- a/src/utils/store.ts
+++ b/src/utils/store.ts
@@ -10,8 +10,8 @@ export const hasLocalStorageItems = (term: string) => {
       console.warn('localStorage is not available in this environment');
       return false;
     }
-    
-    return Object.keys(localStorage).some(key => key.startsWith(term));
+
+    return Object.keys(localStorage).some((key) => key.startsWith(term));
   } catch (error) {
     console.error('Failed to compute localStorage', error);
     return false;

--- a/src/utils/token.ts
+++ b/src/utils/token.ts
@@ -16,13 +16,9 @@ export const decodeAccessToken = (accessToken: string) => {
   return projectId;
 };
 
-export const truncateMiddle = (
-  str: string, 
-  numOfChars: number = 3, 
-  ellipsis: string = '...'
-): string => {
-  const start = str.substring(0, numOfChars);  
+export const truncateMiddle = (str: string, numOfChars: number = 3, ellipsis: string = '...'): string => {
+  const start = str.substring(0, numOfChars);
   const end = str.slice(-numOfChars);
-  
+
   return `${start}${ellipsis}${end}`;
-}
+};

--- a/src/utils/token.ts
+++ b/src/utils/token.ts
@@ -15,3 +15,14 @@ export const decodeAccessToken = (accessToken: string) => {
 
   return projectId;
 };
+
+export const truncateMiddle = (
+  str: string, 
+  numOfChars: number = 3, 
+  ellipsis: string = '...'
+): string => {
+  const start = str.substring(0, numOfChars);  
+  const end = str.slice(-numOfChars);
+  
+  return `${start}${ellipsis}${end}`;
+}

--- a/src/utils/token.ts
+++ b/src/utils/token.ts
@@ -16,7 +16,7 @@ export const decodeAccessToken = (accessToken: string) => {
   return projectId;
 };
 
-export const truncateMiddle = (str: string, numOfChars: number = 3, ellipsis: string = '...'): string => {
+export const truncateMiddle = (str: string, numOfChars = 3, ellipsis = '...'): string => {
   const start = str.substring(0, numOfChars);
   const end = str.slice(-numOfChars);
 


### PR DESCRIPTION
## Why?

Extend session dismissal checkups (clear login-button items cookie only)

## How?

- Extend validation to include descriptive use-cases which when found faulty cause the authentication failure callback to trigger

## Tickets?

- [PLAT-2312](https://linear.app/fleekxyz/issue/PLAT-2312/login-button-cross-session-dismissal-requires-a-further-invalidation)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [ ] Document filename is named after the slug
- [ ] You've reviewed spelling using a grammar checker
- [ ] For documentation, guides or references, you've tested the commands and steps
- [ ] You've done enough research before writing

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] The Components are escaping output (to prevent XSS)

## References?

Optionally, provide references such as links

## Preview?

Optionally, provide the preview url here
