### PR TITLE
refactor: 💡 Remove dataField from graphql client

### DIFF
--- a/.changeset/chilled-bears-watch.md
+++ b/.changeset/chilled-bears-watch.md
@@ -1,0 +1,5 @@
+---
+"@fleek-platform/login-button": minor
+---
+
+Deprecate dataField from graphql client

--- a/src/api/graphql-client.ts
+++ b/src/api/graphql-client.ts
@@ -19,7 +19,6 @@ interface GraphQLOperation<Variables extends UserSessionDetails, Result> {
   operationName: string;
   query: string;
   variables?: Variables;
-  dataField: keyof GraphQLResponse<Result>['data'];
 }
 
 type ProjectResponse = {
@@ -109,7 +108,7 @@ const executeGraphQLOperation = async <Variables extends UserSessionDetails, Res
 
     return {
       success: true,
-      data: jsonRes.data[operation.dataField],
+      data: jsonRes.data[operation.operationName],
     };
   } catch (err) {
     console.error('Failed to execute GraphQL operation', err);
@@ -137,7 +136,6 @@ export const loginWithDynamic = async (
       }
     `,
     variables: { data: { authToken, projectId } },
-    dataField: 'loginWithDynamic',
   });
 
 // TODO: We'd possibly want to use @fleek-platform/utils-genql-client since hard-typed queries will eventually fail on source change. The utils-genql-client is computed/generated.
@@ -157,7 +155,6 @@ export const generateUserSessionDetails = async (
       }
     `,
     variables: { data: { authToken } },
-    dataField: 'generateUserSessionDetails',
   });
 
 export const me = async (graphqlApiUrl: string, accessToken: string): Promise<ExecGraphQLOperationResult<SessionDetails>> =>
@@ -174,7 +171,6 @@ export const me = async (graphqlApiUrl: string, accessToken: string): Promise<Ex
       }
     `,
     variables: { data: { accessToken } },
-    dataField: 'me',
   });
 
 type ProjectWhereInput = {
@@ -204,5 +200,4 @@ export const project = async (
         id: projectId,
       },
     },
-    dataField: 'project',
   });


### PR DESCRIPTION
## Why?

Remove dataField from graphql client

⚠️ Related to comment https://github.com/fleek-platform/login-button/pull/23/files#diff-a49f608f6446ffc2a15e077aec67061eacddf64ce0675cc8f9b7dc3b9bd0e98bR179

## How?

- Deprecate dataField

## Tickets?

- [PLAT-2322](https://linear.app/fleekxyz/issue/PLAT-2322/remove-datafield-from-graphql-client)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [ ] Document filename is named after the slug
- [ ] You've reviewed spelling using a grammar checker
- [ ] For documentation, guides or references, you've tested the commands and steps
- [ ] You've done enough research before writing

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] The Components are escaping output (to prevent XSS)

## References?

Optionally, provide references such as links

## Preview?

Optionally, provide the preview url here
