### PR TITLE
fix: 🐛 Prevent in-memory Project ID cookie mismatch dismiss user session

### DIFF
--- a/.changeset/neat-terms-beg.md
+++ b/.changeset/neat-terms-beg.md
@@ -1,0 +1,5 @@
+---
+"@fleek-platform/login-button": minor
+---
+
+Prevent in-memory Project ID cookie mismatch dismiss user session

--- a/src/providers/DynamicProvider.tsx
+++ b/src/providers/DynamicProvider.tsx
@@ -88,14 +88,19 @@ const DynamicUtils = ({
   }, [setReinitializeSdk, reinitializeSdk]);
 
   useEffect(() => {
-    if (!graphqlApiUrl || authenticating) return;
-
     const debouncedValidation = debounce(validateUserSessionMemoized, 400);
 
-    debouncedValidation();
+    // TODO: Is visibilitychange supported on all major browsers? Test against `focus`
+    document.addEventListener("visibilitychange", debouncedValidation);
 
-    return () => debouncedValidation.cancel();
-  }, [authenticating, graphqlApiUrl, validateUserSessionMemoized]);
+    // document.addEventListener("focus", debouncedValidation);
+
+    return () => {
+      document.removeEventListener("visibilitychange", debouncedValidation);
+
+      // document.removeEventListener("focus", debouncedValidation);
+    };
+  }, [validateUserSessionMemoized]);
 
   return null;
 };
@@ -163,6 +168,7 @@ const validateUserSession = async ({
 
       return false;
     }
+
     const projectId = decodeAccessToken(cookieAccessToken);
 
     if (!projectId) throw Error(`Expected a Project identifier but got ${projectId || typeof projectId}`);

--- a/src/providers/DynamicProvider.tsx
+++ b/src/providers/DynamicProvider.tsx
@@ -91,12 +91,12 @@ const DynamicUtils = ({
     const debouncedValidation = debounce(validateUserSessionMemoized, 400);
 
     // TODO: Is visibilitychange supported on all major browsers? Test against `focus`
-    document.addEventListener("visibilitychange", debouncedValidation);
+    document.addEventListener('visibilitychange', debouncedValidation);
 
     // document.addEventListener("focus", debouncedValidation);
 
     return () => {
-      document.removeEventListener("visibilitychange", debouncedValidation);
+      document.removeEventListener('visibilitychange', debouncedValidation);
 
       // document.removeEventListener("focus", debouncedValidation);
     };

--- a/src/providers/DynamicProvider.tsx
+++ b/src/providers/DynamicProvider.tsx
@@ -147,11 +147,22 @@ const validateUserSession = async ({
 
     if (!hasDynamicAuthWithAccessTokens || !cookieAccessToken) return false;
 
-    if (!hasMatchingAcessTokenInCookie)
-      throw Error(
-        `Expected ${truncateMiddle(accessToken)} but got ${typeof cookieAccessToken === 'string' ? truncateMiddle(cookieAccessToken) : typeof cookieAccessToken}`,
+    if (!hasMatchingAcessTokenInCookie) {
+      console.error(
+        `Expected ${truncateMiddle(accessToken)} but got ${typeof cookieAccessToken === 'string' ? truncateMiddle(cookieAccessToken) : typeof cookieAccessToken}. The browser tab should reload!`,
       );
 
+      // TODO: When a user switches project in a tab
+      // other open tabs detect a mismatch with the in-memory
+      // versus the cookie project ID and consider it faulty
+      // Instead of dismissing the user session (current
+      // behavior), it'll reload as a temporary solution
+      // until we can properly control the project switcher
+      // with the user's latest preference.
+      window.location.reload();
+
+      return false;
+    }
     const projectId = decodeAccessToken(cookieAccessToken);
 
     if (!projectId) throw Error(`Expected a Project identifier but got ${projectId || typeof projectId}`);

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -79,6 +79,7 @@ export const useAuthStore = create<AuthStore>()((set, get) => ({
     set({
       accessToken,
       projectId,
+      isLoggingIn: false,
     });
 
     cookies.set('accessToken', accessToken);
@@ -96,7 +97,7 @@ export const useAuthStore = create<AuthStore>()((set, get) => ({
     try {
       set({ isLoggingIn: true });
 
-      const { authToken } = get();
+      const { authToken, setAccessToken } = get();
 
       const { graphqlApiUrl } = useConfigStore.getState();
 
@@ -126,13 +127,7 @@ export const useAuthStore = create<AuthStore>()((set, get) => ({
 
       if (decodedProjectId !== projectId) throw Error('Found a project mismatch');
 
-      set({
-        accessToken,
-        projectId,
-        isLoggingIn: false,
-      });
-
-      cookies.set('accessToken', accessToken);
+      setAccessToken(accessToken);
     } catch (err) {
       console.error('Failed to update access token:', err);
 


### PR DESCRIPTION
## Why?

Prevent in-memory Project ID cookie mismatch dismiss user session.

## How?

- On in-memory project id mismatching the cookie id, reloads the page

## Tickets?

- [PLAT-2416](https://linear.app/fleekxyz/issue/PLAT-2416/prevent-in-memory-project-id-cookie-mismatch-dismiss-user-session)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [ ] Document filename is named after the slug
- [ ] You've reviewed spelling using a grammar checker
- [ ] For documentation, guides or references, you've tested the commands and steps
- [ ] You've done enough research before writing

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] The Components are escaping output (to prevent XSS)

## References?

Optionally, provide references such as links

## Preview?

https://github.com/user-attachments/assets/2db2e810-d15d-4485-839c-bf4099aa3c6a

> On tab switch triggers

https://github.com/user-attachments/assets/7c0697c5-b683-4c3d-840b-3423fe35603c


